### PR TITLE
Fix for TypeError in ShipmentSaveAfterObserver

### DIFF
--- a/Observer/ShipmentSaveAfterObserver.php
+++ b/Observer/ShipmentSaveAfterObserver.php
@@ -142,6 +142,6 @@ class ShipmentSaveAfterObserver implements ObserverInterface
             return '';
         }
 
-        return is_array($tracks) ? reset($tracks)->getTrackNumber() : '';
+        return is_array($tracks) ? (string)reset($tracks)->getTrackNumber() : '';
     }
 }


### PR DESCRIPTION
We get the following error on our production environment: "TypeError: Return value of MultiSafepay\ConnectCore\Observer\ShipmentSaveAfterObserver::getTrackingNumber() must be of the type string, int returned".

Our client is using different shipping providers with different tracking numbers. Some tracking numbers do not contain letters. This PR is fixing this issue.