### PR TITLE
Fix float comparison with incompatible types

### DIFF
--- a/Gateway/Request/Builder/ShoppingCartRefundRequestBuilder.php
+++ b/Gateway/Request/Builder/ShoppingCartRefundRequestBuilder.php
@@ -82,7 +82,7 @@ class ShoppingCartRefundRequestBuilder implements BuilderInterface
         }
 
         $msg = 'Refunds with 0 amount can not be processed. Please set a different amount';
-        if ($amount === 0) {
+        if ($amount === 0.0) {
             throw new CouldNotRefundException(__($msg));
         }
 

--- a/Model/Method/GenericAdapter.php
+++ b/Model/Method/GenericAdapter.php
@@ -587,7 +587,7 @@ class GenericAdapter extends Adapter
      */
     public function sale(InfoInterface $payment, float $amount): ?ResultInterface
     {
-        $this->executeCommand(
+        return $this->executeCommand(
             'sale',
             ['payment' => $payment, 'amount' => $amount]
         );

--- a/Service/OrderService.php
+++ b/Service/OrderService.php
@@ -213,7 +213,7 @@ class OrderService
 
         $transactionManager = $this->sdkFactory->create((int)$order->getStoreId())->getTransactionManager();
 
-        $transactionLog = $transaction ?? [];
+        $transactionLog = $transaction;
         unset($transactionLog['payment_details'], $transactionLog['payment_methods']);
 
         $this->logger->logInfoForOrder(


### PR DESCRIPTION
The $amount variable is casted to a float on line 70. Strict checking a float with 0 will always resolve to false.
See: http://sandbox.onlinephpfunctions.com/code/33d898e211ecf37ae50872b37b26549d3e7c7930

I've also added a missing return statement in `MultiSafepay\ConnectCore\Model\Method\GenericAdapter` and i've removed a redundant check in `MultiSafepay\ConnectCore\Service\OrderService`.