### PR TITLE
[BUGFIX] Prevent error when Shipping Description is null

### DIFF
--- a/Model/Api/Builder/OrderRequestBuilder/ShoppingCartBuilder/ShippingItemBuilder.php
+++ b/Model/Api/Builder/OrderRequestBuilder/ShoppingCartBuilder/ShippingItemBuilder.php
@@ -66,7 +66,7 @@ class ShippingItemBuilder implements ShoppingCartBuilderInterface
             $shippingPrice = $this->priceUtil->getShippingUnitPrice($order);
 
             $items[] = (new Item())
-                ->addName($order->getShippingDescription())
+                ->addName($order->getShippingDescription() ?: 'shipment')
                 ->addUnitPrice(new Money($shippingPrice * 100, $currency))
                 ->addQuantity(1)
                 ->addDescription('Shipping')


### PR DESCRIPTION
When the Shipping Description is null, Multisafepay will error on creating the transaction and invoice for the order. Meaning the order will be paid, but will stay on 'Pending Payment' (and eventually be cancelled) in Multisafepay.

There are several reasons why ShippingDescription might be empty - in our case, we change shipping after order-save. But Magento does not actually have a 'hard' requirement on shipping description, so there might be many cases where shipping description is empty.