### PR TITLE
Add can_fetch_transaction_info to payment methods

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -32,6 +32,7 @@
                 <title>MultiSafepay</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -55,6 +56,7 @@
                 <title>iDEAL</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -78,6 +80,7 @@
                 <title>Pay After Delivery</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>0</can_use_internal>
                 <can_refund>1</can_refund>
@@ -102,6 +105,7 @@
                 <title>Klarna - buy now, pay later</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>0</can_use_internal>
                 <can_refund>1</can_refund>
@@ -126,6 +130,7 @@
                 <title>Afterpay</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>0</can_use_internal>
                 <can_refund>1</can_refund>
@@ -150,6 +155,7 @@
                 <title>Bancontact</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -175,6 +181,7 @@
                 <payment_type>redirect</payment_type>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -198,6 +205,7 @@
                 <title>Apple Pay</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -222,6 +230,7 @@
                 <title>Belfius</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -247,6 +256,7 @@
                 <title>Credit Card</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_authorize_vault>1</can_authorize_vault>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
@@ -413,6 +423,7 @@
                 <title>Dotpay</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -437,6 +448,7 @@
                 <title>EPS</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -461,6 +473,7 @@
                 <title>Giropay</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -485,6 +498,7 @@
                 <title>iDEAL QR</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -510,6 +524,7 @@
                 <payment_type>redirect</payment_type>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -538,6 +553,7 @@
                 <payment_type>redirect</payment_type>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -565,6 +581,7 @@
                 <title>Paysafecard</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -589,6 +606,7 @@
                 <title>SOFORT Banking</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -613,6 +631,7 @@
                 <title>TrustPay</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -638,6 +657,7 @@
                 <payment_type>redirect</payment_type>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -666,6 +686,7 @@
                 <title>Alipay</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -690,6 +711,7 @@
                 <title>Request To Pay</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -714,6 +736,7 @@
                 <title>Bank Transfer</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -738,6 +761,7 @@
                 <title>Santander Pay per Month</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>0</can_use_internal>
                 <can_refund>1</can_refund>
@@ -762,6 +786,7 @@
                 <title>CBC</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -786,6 +811,7 @@
                 <title>Direct Debit</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -810,6 +836,7 @@
                 <title>E-invoicing</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -834,6 +861,7 @@
                 <title>ING Home'Pay</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -858,6 +886,7 @@
                 <title>KBC</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -882,6 +911,7 @@
                 <title>Paypal</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -906,6 +936,7 @@
                 <title>Trustly</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -930,6 +961,7 @@
                 <title>in3</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>0</can_use_internal>
                 <can_refund>1</can_refund>
@@ -955,6 +987,7 @@
                 <order_status>pending</order_status>
                 <payment_action>initialize</payment_action>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_use_internal>1</can_use_internal>
                 <can_refund>1</can_refund>
@@ -984,6 +1017,7 @@
                 <title>Baby Giftcard</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <is_gateway>1</is_gateway>
                 <sort_order>1</sort_order>
@@ -1005,6 +1039,7 @@
                 <title>Beauty and wellness</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <is_gateway>1</is_gateway>
                 <sort_order>1</sort_order>
@@ -1026,6 +1061,7 @@
                 <title>Boekenbon</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <is_gateway>1</is_gateway>
                 <sort_order>1</sort_order>
@@ -1047,6 +1083,7 @@
                 <title>Fashioncheque</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <is_gateway>1</is_gateway>
                 <sort_order>1</sort_order>
@@ -1068,6 +1105,7 @@
                 <title>Fashion gift card</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <is_gateway>1</is_gateway>
                 <sort_order>1</sort_order>
@@ -1089,6 +1127,7 @@
                 <title>Fietsenbon</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <is_gateway>1</is_gateway>
                 <sort_order>1</sort_order>
@@ -1110,6 +1149,7 @@
                 <title>Gezondheidsbon</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <is_gateway>1</is_gateway>
                 <sort_order>1</sort_order>
@@ -1131,6 +1171,7 @@
                 <title>Givacard</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <is_gateway>1</is_gateway>
                 <sort_order>1</sort_order>
@@ -1152,6 +1193,7 @@
                 <title>Good4fun Giftcard</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <is_gateway>1</is_gateway>
                 <sort_order>1</sort_order>
@@ -1173,6 +1215,7 @@
                 <title>Goodcard</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <is_gateway>1</is_gateway>
                 <sort_order>1</sort_order>
@@ -1194,6 +1237,7 @@
                 <title>Nationale tuinbon</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <is_gateway>1</is_gateway>
                 <sort_order>1</sort_order>
@@ -1215,6 +1259,7 @@
                 <title>Parfum cadeaukaart</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <can_refund>1</can_refund>
                 <is_gateway>1</is_gateway>
@@ -1237,6 +1282,7 @@
                 <title>Podium cadeaukaart</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <is_gateway>1</is_gateway>
                 <sort_order>1</sort_order>
@@ -1258,6 +1304,7 @@
                 <title>Sport &amp; Fit</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <is_gateway>1</is_gateway>
                 <sort_order>1</sort_order>
@@ -1279,6 +1326,7 @@
                 <title>VVV cadeaukaart</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <is_gateway>1</is_gateway>
                 <sort_order>1</sort_order>
@@ -1300,6 +1348,7 @@
                 <title>Webshop Giftcard</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <is_gateway>1</is_gateway>
                 <sort_order>1</sort_order>
@@ -1321,6 +1370,7 @@
                 <title>Wellness Giftcard</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <is_gateway>1</is_gateway>
                 <sort_order>1</sort_order>
@@ -1342,6 +1392,7 @@
                 <title>Wijn Cadeau</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <is_gateway>1</is_gateway>
                 <sort_order>1</sort_order>
@@ -1363,6 +1414,7 @@
                 <title>Winkel Cheque</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <is_gateway>1</is_gateway>
                 <sort_order>1</sort_order>
@@ -1384,6 +1436,7 @@
                 <title>YourGift</title>
                 <currency>EUR</currency>
                 <can_initialize>1</can_initialize>
+                <can_fetch_transaction_info>1</can_fetch_transaction_info>
                 <can_use_checkout>1</can_use_checkout>
                 <is_gateway>1</is_gateway>
                 <sort_order>1</sort_order>


### PR DESCRIPTION
This enables the 'Fetch' button in the Magento admin transaction overview.

Seems to work perfectly fine, but the capability was just not defined.

<img width="1932" alt="Screenshot 2021-09-14 at 10 39 43" src="https://user-images.githubusercontent.com/2959888/133225117-66fd771d-2984-4d37-9d5a-cfcba0696128.png">

