### PR TITLE
Fix notices when no postcode is present on the address

### DIFF
--- a/Model/Api/Builder/OrderRequestBuilder/CustomerBuilder/AddressBuilder.php
+++ b/Model/Api/Builder/OrderRequestBuilder/CustomerBuilder/AddressBuilder.php
@@ -59,8 +59,8 @@ class AddressBuilder
 
         return $orderRequestAddress->addCity($address->getCity())
             ->addCountry(new Country($address->getCountryId()))
-            ->addHouseNumber($streetAndHouseNumber[1])
-            ->addStreetName($streetAndHouseNumber[0])
-            ->addZipCode(trim($address->getPostcode()));
+            ->addHouseNumber($streetAndHouseNumber[1] ?? '')
+            ->addStreetName($streetAndHouseNumber[0] ?? '')
+            ->addZipCode(trim($address->getPostcode() ?: ''));
     }
 }


### PR DESCRIPTION
Some shops do not make postal codes required, this leads to a problem when checking out because calling `trim()` on `NULL` yields a notice in PHP