### PR TITLE
Null customer ID when requesting guest payment url

### DIFF
--- a/Model/PaymentUrl.php
+++ b/Model/PaymentUrl.php
@@ -65,7 +65,7 @@ class PaymentUrl implements PaymentUrlInterface
      * @param int|null $cartId
      * @return string
      */
-    public function getPaymentUrl(int $orderId, int $customerId, ?int $cartId = null): string
+    public function getPaymentUrl(int $orderId, ?int $customerId, ?int $cartId = null): string
     {
         try {
             $order = $this->orderRepository->get($orderId);


### PR DESCRIPTION
This function throws an error when attempting to retrieve a payment url when checking out as guest, because int is not nullable by default.