### PR TITLE
Upgrade to Monolog 3.9 syntax

### DIFF
--- a/Logger/Handler.php
+++ b/Logger/Handler.php
@@ -28,9 +28,9 @@ class Handler extends Base
     protected $fileName = '/var/log/multisafepay.log';
 
     /**
-     * @var int
+     * @var \Monolog\Level
      */
-    protected $level = Logger::INFO;
+    protected \Monolog\Level $level = \Monolog\Level::Info;
 
     /**
      * @var Config
@@ -57,15 +57,15 @@ class Handler extends Base
     }
 
     /**
-     * @param array $record
+     * @param \Monolog\LogRecord $record
      * @return bool
      */
-    public function isHandling(array $record): bool
+    public function isHandling(\Monolog\LogRecord $record): bool
     {
         if ($this->config->isDebug()) {
             return true;
         }
 
-        return $record['level'] >= Logger::WARNING;
+        return $record['level'] >= \Monolog\Level::Warning->value;
     }
 }


### PR DESCRIPTION
In commit https://github.com/Seldaek/monolog/commit/2d006a847235a3308510f638a27b8d12df1d1134, Monolog changed various simple types to value objects. In Magento, the upgrade of the `psr/log` package from 1 to 1-3 allows an upgrade to Monolog 3.9 as well, which brings this change into Magento. Without the changes in this PR, DI compilation fails under Magento 2.4.8.